### PR TITLE
Update KituraMarkdown.swift

### DIFF
--- a/Sources/KituraMarkdown/KituraMarkdown.swift
+++ b/Sources/KituraMarkdown/KituraMarkdown.swift
@@ -57,14 +57,16 @@ public class KituraMarkdown: TemplateEngine {
     ///            using Markdown.
     public static func render(from: Data) -> String {
         return from.withUnsafeBytes() { (bytes: UnsafePointer<Int8>) -> String in
-        
+            var html = "<!DOCTYPE html>\n<html>"
+            
             guard let htmlBytes = cmark_markdown_to_html(bytes, from.count, 0) else { return "" }
 
-            let html = String(utf8String: htmlBytes)
+            html += String(utf8String: htmlBytes) ?? ""
+			html += "</html>"
 
             free(htmlBytes)
 
-            return html ?? ""
+            return html
         }
     }
 


### PR DESCRIPTION
There's a huge chance that chrome will treat the rendered page as text/plain
the best way to fix this other than manually setting content-type is to add doc type to the page.