### PR TITLE
Enable wrapping generated markdown to a static HTML page

### DIFF
--- a/Sources/KituraMarkdown/KituraMarkdown.swift
+++ b/Sources/KituraMarkdown/KituraMarkdown.swift
@@ -50,6 +50,27 @@ public class KituraMarkdown: TemplateEngine {
         return  KituraMarkdown.render(from: md)
     }
 
+    /// Take a template file in Markdown format and generate HTML format content to
+    /// be sent back to the client.
+    ///
+    /// - Parameter filePath: The path of the template file in Markdown format to use
+    ///                      when generating the content.
+    /// - Parameter context: A set of variables in the form of a Dictionary of
+    ///                     Key/Value pairs. **Note:** This parameter is ignored at
+    ///                     this time
+    /// - Parameter pageTemplate: The HTML page template to insert rendered markdown into.
+    ///                     Passing in "default" will insert markdown as a child of <body>
+    ///                     Custom HTML template should indicate location of insertion with
+    ///                     <snippetInsertLocation></snippetInsertLocation> tag.
+    ///
+    /// - Returns: If an Error isn't thrown whenreading the template, a String containing
+    ///            an HTML representation of the text marked up using Markdown.
+    public func render(filePath: String, context: [String: Any], pageTemplate: String) throws -> String {
+        let md = try Data(contentsOf: URL(fileURLWithPath: filePath))
+        let snippet = KituraMarkdown.render(from: md)
+        return  KituraMarkdown.createPage(from: snippet, withTemplate: pageTemplate)
+    }
+
     /// Generate HTML from a Data struct containing text marked up in Markdown in the
     /// form of UTF-8 bytes. 
     ///
@@ -75,5 +96,26 @@ public class KituraMarkdown: TemplateEngine {
     public static func render(from: String) -> String {
         let md = from.data(using: .utf8)
         return  md != nil ? KituraMarkdown.render(from: md!) : ""
+    }
+
+    /// Generate HTML from a String containing text marked up in Markdown.
+    ///
+    /// - Returns: A String containing an HTML representation of the text marked up
+    ///            using Markdown.
+    public static func render(from: String, pageTemplate: String) -> String {
+        let md = from.data(using: .utf8)
+        let snippet = md != nil ? KituraMarkdown.render(from: md!) : ""
+        return  KituraMarkdown.createPage(from: snippet, withTemplate: pageTemplate)
+    }
+
+    /// Wrap markdown
+    private static func createPage(from: String, withTemplate: String) -> String {
+        if(withTemplate == "default") {
+            return "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"UTF-8\"><title>Title</title></head><body>\(from)</body></html>"
+        }
+
+        let result = withTemplate.replacingOccurrences(of: "<snippetInsertLocation></snippetInsertLocation>", with: from)
+
+        return (result == withTemplate ? from : result)
     }
 }

--- a/Tests/KituraMarkdownTests/BasicTests.swift
+++ b/Tests/KituraMarkdownTests/BasicTests.swift
@@ -52,23 +52,11 @@ class BasicTests: XCTestCase {
         }
     }
 
-    func testSimpleEmptyStringWithDefaultPageTemplate() {
-        let html = KituraMarkdown.render(from: "")
-        let expected = ""
-        XCTAssertEqual(html, expected, "Converted HTML wasn't [\(expected)] it was [\(html)]")
-    }
-
-    func testSimpleMarkdownStringWithDefaultPageTemplate() {
-        let html = KituraMarkdown.render(from: "1. A\n2. B\n", pageTemplate: "default")
-        let expected = "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"UTF-8\"><title>Title</title></head><body><ol>\n<li>A</li>\n<li>B</li>\n</ol>\n</body></html>"
-        XCTAssertEqual(html, expected, "Converted HTML wasn't [\(expected)] it was [\(html)]")
-    }
-
     func testSimpleMarkdownFileWithDefaultPageTemplate() {
         let engine = KituraMarkdown()
         let filename = getBaseSourceLocation() + "simple-text.md"
         do {
-            let html = try engine.render(filePath: filename, context: [String:Any](), pageTemplate: "default")
+            let html = try engine.render(filePath: filename, context: [String:Any](), options: ["useTemplate": "default"])
             let expected = "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"UTF-8\"><title>Title</title></head><body><ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n</ul>\n</body></html>"
             XCTAssertEqual(html, expected, "Converted HTML wasn't [\(expected)] it was [\(html)]")
         }
@@ -106,8 +94,6 @@ extension BasicTests {
             ("testSimpleMarkdownString", testSimpleMarkdownString),
              ("testEngineFileExtension", testEngineFileExtension),
              ("testSimpleMarkdownFile", testSimpleMarkdownFile),
-             ("testSimpleEmptyStringWithDefaultPageTemplate", testSimpleEmptyStringWithDefaultPageTemplate),
-             ("testSimpleMarkdownStringWithDefaultPageTemplate", testSimpleMarkdownStringWithDefaultPageTemplate),
              ("testSimpleMarkdownFileWithDefaultPageTemplate", testSimpleMarkdownFileWithDefaultPageTemplate)
              /* ("testSwiftMarkdownString", testSwiftMarkdownString) */
     ]

--- a/Tests/KituraMarkdownTests/BasicTests.swift
+++ b/Tests/KituraMarkdownTests/BasicTests.swift
@@ -20,13 +20,19 @@ import XCTest
 @testable import KituraMarkdown
 
 class BasicTests: XCTestCase {
-  
+
+    func testSimpleEmptyString() {
+        let html = KituraMarkdown.render(from: "")
+        let expected = ""
+        XCTAssertEqual(html, expected, "Converted HTML wasn't [\(expected)] it was [\(html)]")
+    }
+
     func testSimpleMarkdownString() {
         let html = KituraMarkdown.render(from: "1. A\n2. B\n")
         let expected = "<ol>\n<li>A</li>\n<li>B</li>\n</ol>\n"
         XCTAssertEqual(html, expected, "Converted HTML wasn't [\(expected)] it was [\(html)]")
     }
-  
+
     func testEngineFileExtension() {
         let engine = KituraMarkdown()
         let ext = engine.fileExtension
@@ -39,6 +45,31 @@ class BasicTests: XCTestCase {
         do {
             let html = try engine.render(filePath: filename, context: [String:Any]())
             let expected = "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n</ul>\n"
+            XCTAssertEqual(html, expected, "Converted HTML wasn't [\(expected)] it was [\(html)]")
+        }
+        catch let error {
+            XCTFail("Caught an error. The error was of type \(type(of: error))")
+        }
+    }
+
+    func testSimpleEmptyStringWithDefaultPageTemplate() {
+        let html = KituraMarkdown.render(from: "")
+        let expected = ""
+        XCTAssertEqual(html, expected, "Converted HTML wasn't [\(expected)] it was [\(html)]")
+    }
+
+    func testSimpleMarkdownStringWithDefaultPageTemplate() {
+        let html = KituraMarkdown.render(from: "1. A\n2. B\n", pageTemplate: "default")
+        let expected = "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"UTF-8\"><title>Title</title></head><body><ol>\n<li>A</li>\n<li>B</li>\n</ol>\n</body></html>"
+        XCTAssertEqual(html, expected, "Converted HTML wasn't [\(expected)] it was [\(html)]")
+    }
+
+    func testSimpleMarkdownFileWithDefaultPageTemplate() {
+        let engine = KituraMarkdown()
+        let filename = getBaseSourceLocation() + "simple-text.md"
+        do {
+            let html = try engine.render(filePath: filename, context: [String:Any](), pageTemplate: "default")
+            let expected = "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"UTF-8\"><title>Title</title></head><body><ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n</ul>\n</body></html>"
             XCTAssertEqual(html, expected, "Converted HTML wasn't [\(expected)] it was [\(html)]")
         }
         catch let error {
@@ -71,9 +102,13 @@ class BasicTests: XCTestCase {
 extension BasicTests {
   static var allTests : [(String, (BasicTests) -> () throws -> Void)] {
     return [
-             ("testSimpleMarkdownString", testSimpleMarkdownString),
+            ("testSimpleEmptyString", testSimpleEmptyString),
+            ("testSimpleMarkdownString", testSimpleMarkdownString),
              ("testEngineFileExtension", testEngineFileExtension),
-             ("testSimpleMarkdownFile", testSimpleMarkdownFile)
+             ("testSimpleMarkdownFile", testSimpleMarkdownFile),
+             ("testSimpleEmptyStringWithDefaultPageTemplate", testSimpleEmptyStringWithDefaultPageTemplate),
+             ("testSimpleMarkdownStringWithDefaultPageTemplate", testSimpleMarkdownStringWithDefaultPageTemplate),
+             ("testSimpleMarkdownFileWithDefaultPageTemplate", testSimpleMarkdownFileWithDefaultPageTemplate)
              /* ("testSwiftMarkdownString", testSwiftMarkdownString) */
     ]
   }


### PR DESCRIPTION
Template Engine implementation for Markdown that addresses the request in IBM-Swift/Kitura#930.
User may pass "useTemplate" as an option to generate a fully spec-ed static HTML page.