### PR TITLE
Swift 4.1 support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", .upToNextMinor(from: "1.7.0"))
+        .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Update the Kitura-TemplateEngine dependency to `2.0.0`, required to resolve Kitura's package tree with Swift 4.1 support.