### PR TITLE
Support Swift 3.1.1 thru 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
     - os: osx
       osx_image: xcode8.3
       sudo: required
+      env: SWIFT_SNAPSHOT=3.1.1
     - os: osx
       osx_image: xcode9.2
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,13 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      env: SWIFT_SNAPSHOT=3.1.1
+    - os: linux
+      dist: trusty
+      sudo: required
+    - os: osx
+      osx_image: xcode8.3
+      sudo: required
     - os: osx
       osx_image: xcode9.2
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.1-DEVELOPMENT-SNAPSHOT-2018-02-26-a
     - os: osx
       osx_image: xcode8.3
       sudo: required
@@ -24,6 +28,10 @@ matrix:
     - os: osx
       osx_image: xcode9.2
       sudo: required
+    - os: osx
+      osx_image: xcode9.3beta
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.1-DEVELOPMENT-SNAPSHOT-2018-02-26-a
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Package.pins
+++ b/Package.pins
@@ -1,0 +1,5 @@
+{
+  "autoPin": false,
+  "pins": [],
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,6 @@
-// swift-tools-version:4.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
+// swift-tools-version:3.1
 /**
- * Copyright IBM Corporation 2017
+ * Copyright IBM Corporation 2016, 2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,29 +19,12 @@ import PackageDescription
 
 let package = Package(
     name: "KituraMarkdown",
-    products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .library(
-            name: "KituraMarkdown",
-            targets: ["KituraMarkdown"]
-        )
+    targets: [
+        Target(name: "KituraMarkdown", dependencies: ["Ccmark"]),
+        Target(name: "Ccmark", dependencies: [])
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0")
-    ],
-    targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(
-            name: "Ccmark"
-        ),
-        .target(
-            name: "KituraMarkdown",
-            dependencies: ["Ccmark", "KituraTemplateEngine"]
-        ),
-        .testTarget(
-            name: "KituraMarkdownTests",
-            dependencies: ["KituraMarkdown"]
-        )
+        .Package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", majorVersion: 1, minor: 7)
     ]
 )
+

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,49 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+/**
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import PackageDescription
+
+let package = Package(
+    name: "KituraMarkdown",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "KituraMarkdown",
+            targets: ["KituraMarkdown"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", .upToNextMinor(from: "1.7.0"))
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "Ccmark"
+        ),
+        .target(
+            name: "KituraMarkdown",
+            dependencies: ["Ccmark", "KituraTemplateEngine"]
+        ),
+        .testTarget(
+            name: "KituraMarkdownTests",
+            dependencies: ["KituraMarkdown"]
+        )
+    ]
+)


### PR DESCRIPTION
- Restore Swift 3.1 support
- Support Swift 4.0 and 4.1 via `Package@swift-4.swift`
- Travis for 3.1.1, 4.0 and 4.1